### PR TITLE
Make sure to explicitly set Java 8 for source and compiler target

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,16 @@
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.8.0</version>
+					<configuration>
+						<source>${maven.compiler.source}</source>
+						<target>${maven.compiler.target}</target>
+						<encoding>${project.build.sourceEncoding}</encoding>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
 					<version>3.0.2</version>
 				</plugin>


### PR DESCRIPTION
Needed for IntelliJ to compile dependent projects to correct compiler version by default.